### PR TITLE
Find generated header files when building as part of a catkin workspa…

### DIFF
--- a/irgUtil/CMakeLists.txt
+++ b/irgUtil/CMakeLists.txt
@@ -11,8 +11,9 @@ if (catkin_FOUND)
   ###################################
   ## catkin specific configuration ##
   ###################################
+  file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
   catkin_package(
-    INCLUDE_DIRS src
+    INCLUDE_DIRS src ${CATKIN_DEVEL_PREFIX}/include
     LIBRARIES irgSha1 irgUtmll
   )
 else (catkin_FOUND)
@@ -47,6 +48,7 @@ find_package(Doxygen)
 include_directories(
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_BINARY_DIR}/src
+  ${CATKIN_DEVEL_PREFIX}/include
 )
 
 ## set variables for config file

--- a/kn/CMakeLists.txt
+++ b/kn/CMakeLists.txt
@@ -11,8 +11,9 @@ if (catkin_FOUND)
 ###################################
 ## catkin specific configuration ##
 ###################################
+file(MAKE_DIRECTORY ${CATKIN_DEVEL_PREFIX}/include)
 catkin_package(
-  INCLUDE_DIRS src
+  INCLUDE_DIRS src ${CATKIN_DEVEL_PREFIX}/include
   LIBRARIES knShare knMath knGeometry knFrameStore knMotorShare
   )
 else (catkin_FOUND)
@@ -50,6 +51,7 @@ find_package( Doxygen )
 include_directories(
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_BINARY_DIR}/src
+  ${CATKIN_DEVEL_PREFIX}/include
 )
 
 #


### PR DESCRIPTION
Fixed issue where generated header files were not located by catkin when building as part of a catkin workspace. Verified fix using ROS Indigo and a catkin workspace containing only soraCore and irg_cmake packages.
